### PR TITLE
Avoid calling static initializer code at compile time

### DIFF
--- a/src/clj/clojure/core_proxy.clj
+++ b/src/clj/clojure/core_proxy.clj
@@ -257,7 +257,7 @@
   [& bases]
     (let [[super interfaces] (get-super-and-interfaces bases)
           pname (proxy-name super interfaces)]
-      (or (RT/getClassForNameNonLoading pname)
+      (or (RT/loadClassForName pname false)
           (let [[cname bytecode] (generate-proxy super interfaces)]
             (. ^DynamicClassLoader (deref clojure.lang.Compiler/LOADER) (defineClass pname bytecode [super interfaces]))))))
 

--- a/src/clj/clojure/core_proxy.clj
+++ b/src/clj/clojure/core_proxy.clj
@@ -257,7 +257,7 @@
   [& bases]
     (let [[super interfaces] (get-super-and-interfaces bases)
           pname (proxy-name super interfaces)]
-      (or (RT/loadClassForName pname)
+      (or (RT/getClassForNameNonLoading pname)
           (let [[cname bytecode] (generate-proxy super interfaces)]
             (. ^DynamicClassLoader (deref clojure.lang.Compiler/LOADER) (defineClass pname bytecode [super interfaces]))))))
 
@@ -406,6 +406,3 @@
                    (when-let [pseq (seq plseq)]
                      (cons (new clojure.lang.MapEntry (first pseq) (v (first pseq)))
                            (thisfn (rest pseq)))))) (keys pmap))))))
-
-
-

--- a/src/clj/clojure/genclass.clj
+++ b/src/clj/clojure/genclass.clj
@@ -106,7 +106,7 @@
    (class? x) x
    (contains? prim->class x) (prim->class x)
    :else (let [strx (str x)]
-           (clojure.lang.RT/classForName 
+           (clojure.lang.RT/classForNameNonLoading 
             (if (some #{\. \[} strx)
               strx
               (str "java.lang." strx))))))

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -1014,7 +1014,7 @@ static public abstract class HostExpr implements Expr, MaybePrimitiveExpr{
 				if(Util.equals(sym,COMPILE_STUB_SYM.get()))
 					return (Class) COMPILE_STUB_CLASS.get();
 				if(sym.name.indexOf('.') > 0 || sym.name.charAt(0) == '[')
-					c = RT.classForName(sym.name);
+					c = RT.classForNameNonLoading(sym.name);
 				else
 					{
 					Object o = currentNS().getMapping(sym);
@@ -1025,7 +1025,7 @@ static public abstract class HostExpr implements Expr, MaybePrimitiveExpr{
 					else
 						{
 						try{
-						c = RT.classForName(sym.name);
+						c = RT.classForNameNonLoading(sym.name);
 						}
 						catch(Exception e){
 							// aargh
@@ -1036,7 +1036,7 @@ static public abstract class HostExpr implements Expr, MaybePrimitiveExpr{
 				}
 			}
 		else if(stringOk && form instanceof String)
-			c = RT.classForName((String) form);
+			c = RT.classForNameNonLoading((String) form);
 		return c;
 	}
 

--- a/src/jvm/clojure/lang/RT.java
+++ b/src/jvm/clojure/lang/RT.java
@@ -2167,26 +2167,11 @@ static public Class classForNameNonLoading(String name) {
 	return classForName(name, false, baseLoader());
 }
 
-static public Class loadClassForName(String name) {
-	try
-		{
-		classForNameNonLoading(name);
-		}
-	catch(Exception e)
-		{
-		if (e instanceof ClassNotFoundException)
-			return null;
-		else
-			throw Util.sneakyThrow(e);
-		}
-	return classForName(name);
-}
-
-static public Class getClassForNameNonLoading(String name) {
+static public Class loadClassForName(String name, boolean load) {
 	Class c = null;
 	try
 		{
-		c = classForNameNonLoading(name);
+		c = classForName(name, load, baseLoader());
 		}
 	catch(Exception e)
 		{
@@ -2196,6 +2181,10 @@ static public Class getClassForNameNonLoading(String name) {
 			throw Util.sneakyThrow(e);
 		}
 	return c;
+}
+
+static public Class loadClassForName(String name) {
+	return loadClassForName(name, true);
 }
 
 static public float aget(float[] xs, int i){

--- a/src/jvm/clojure/lang/RT.java
+++ b/src/jvm/clojure/lang/RT.java
@@ -2182,6 +2182,22 @@ static public Class loadClassForName(String name) {
 	return classForName(name);
 }
 
+static public Class getClassForNameNonLoading(String name) {
+	Class c = null;
+	try
+		{
+		c = classForNameNonLoading(name);
+		}
+	catch(Exception e)
+		{
+		if (e instanceof ClassNotFoundException)
+			return null;
+		else
+			throw Util.sneakyThrow(e);
+		}
+	return c;
+}
+
 static public float aget(float[] xs, int i){
 	return xs[i];
 }


### PR DESCRIPTION
The Clojure change http://dev.clojure.org/jira/browse/CLJ-1315 (which is included in Clojure 1.7) modified `import` to load classes without calling static initializers on them. This lets you refer to classes without running their initialization code, which may not execute successfully at compile time. (An example of a time this is necessary is AOT-compiling code which calls RoboVM libraries).

This PR adds two additional places where classes are loaded without running static initializers:
- When extending a class in `:gen-class`
- When using `proxy`
